### PR TITLE
Multi part validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,19 @@ Or install it yourself as:
 
 You can change the number of parts of the generated code by passing an option hash value like:
 
-    >> CouponCode.generate(parts: 4)
+    >> code = CouponCode.generate(parts: 4)
     => "1K7Q-CTFM-LMTC-DLGP"
+    >> CouponeCode.validate(code, parts: 4)
+    => "1K7Q-CTFM-LMTC-DLGP"
+
+You can also set the default number of parts you are working with so that you don't have to continually send the parts value as an option:
+
+    >> CouponCode.default_parts(5)
+    => 5
+    >> code = CouponCode.generate
+    => "CNYF-K4AH-L5PF-0RU7-5L0Q"
+    >> CouponCode.validate(code)
+    => "CNYF-K4AH-L5PF-0RU7-5L0Q"
 
 ## Testing
 

--- a/lib/coupon_code.rb
+++ b/lib/coupon_code.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 require 'digest/sha1'
 
 module CouponCode
-  SYMBOL  = '0123456789ABCDEFGHJKLMNPQRTUVWXY'
+  SYMBOL  = "0123456789ABCDEFGHJKLMNPQRTUVWXY"
   LENGTH  = 4
   @@parts = 3
 
@@ -21,7 +21,7 @@ module CouponCode
 
   def self.validate(orig, options = { parts: @@parts })
     num_parts = options.delete(:parts)
-    code      = orig.upcase.gsub(/[^0-9A-Z]+/, '')
+    code      = orig.upcase.gsub(/[^0-9A-Z]+/, "")
     parts     = code.scan(/[0-9A-Z]{#{LENGTH}}/)
 
     return if parts.length != num_parts

--- a/lib/coupon_code.rb
+++ b/lib/coupon_code.rb
@@ -3,11 +3,11 @@ require 'securerandom'
 require 'digest/sha1'
 
 module CouponCode
-  SYMBOL = '0123456789ABCDEFGHJKLMNPQRTUVWXY'
-  PARTS  = 3
-  LENGTH = 4
+  SYMBOL  = '0123456789ABCDEFGHJKLMNPQRTUVWXY'
+  LENGTH  = 4
+  @@parts = 3
 
-  def self.generate(options = { parts: PARTS })
+  def self.generate(options = { parts: @@parts })
     num_parts = options.delete(:parts)
     parts = []
     (1..num_parts).each do |i|
@@ -34,6 +34,10 @@ module CouponCode
     end
 
     parts.join('-')
+  end
+
+  def self.default_parts(parts)
+    @@parts = parts
   end
 
   def self.checkdigit_alg_1(orig, check)

--- a/lib/coupon_code.rb
+++ b/lib/coupon_code.rb
@@ -9,7 +9,7 @@ module CouponCode
 
   def self.generate(options = { parts: @@parts })
     (1..options[:parts]).map do |i|
-      part = ''
+      part = ""
       (1...LENGTH).each { part << random_symbol }
       part << checkdigit_alg_1(part, i)
 
@@ -31,7 +31,7 @@ module CouponCode
       return if check != checkdigit_alg_1(data, i + 1)
     end
 
-    parts.join('-')
+    parts.join("-")
   end
 
   def self.default_parts(parts)

--- a/lib/coupon_code.rb
+++ b/lib/coupon_code.rb
@@ -38,6 +38,8 @@ module CouponCode
     @@parts = parts
   end
 
+  private
+
   def self.checkdigit_alg_1(orig, check)
     orig.split('').each_with_index do |c, _|
       k = SYMBOL.index(c)

--- a/lib/coupon_code.rb
+++ b/lib/coupon_code.rb
@@ -8,15 +8,13 @@ module CouponCode
   @@parts = 3
 
   def self.generate(options = { parts: @@parts })
-    num_parts = options.delete(:parts)
-    parts = []
-    (1..num_parts).each do |i|
+    (1..options[:parts]).map do |i|
       part = ''
       (1...LENGTH).each { part << random_symbol }
       part << checkdigit_alg_1(part, i)
-      parts << part
-    end
-    parts.join('-')
+
+      part
+    end.join("-")
   end
 
   def self.validate(orig, options = { parts: @@parts })

--- a/lib/coupon_code.rb
+++ b/lib/coupon_code.rb
@@ -19,16 +19,20 @@ module CouponCode
     parts.join('-')
   end
 
-  def self.validate(orig, num_parts = PARTS)
-    code = orig.upcase
-    code.gsub!(/[^0-9A-Z]+/, '')
-    parts = code.scan(/[0-9A-Z]{#{LENGTH}}/)
+  def self.validate(orig, options = { parts: @@parts })
+    num_parts = options.delete(:parts)
+    code      = orig.upcase.gsub(/[^0-9A-Z]+/, '')
+    parts     = code.scan(/[0-9A-Z]{#{LENGTH}}/)
+
     return if parts.length != num_parts
+
     parts.each_with_index do |part, i|
       data  = part[0...(LENGTH - 1)]
       check = part[-1]
+
       return if check != checkdigit_alg_1(data, i + 1)
     end
+
     parts.join('-')
   end
 

--- a/lib/coupon_code/version.rb
+++ b/lib/coupon_code/version.rb
@@ -1,3 +1,3 @@
 module CouponCode
-  VERSION = '0.1.0'
+  VERSION = "0.1.0"
 end

--- a/lib/coupon_code/version.rb
+++ b/lib/coupon_code/version.rb
@@ -1,3 +1,3 @@
 module CouponCode
-  VERSION = '0.0.1'
+  VERSION = '0.1.0'
 end

--- a/test/coupon_code_test.rb
+++ b/test/coupon_code_test.rb
@@ -52,11 +52,11 @@ describe CouponCode do
     end
 
     it 'should accept a short code with correct parts.' do
-      CouponCode.validate('1K7Q-CTFM', 2).wont_be_nil
+      CouponCode.validate('1K7Q-CTFM', parts: 2).wont_be_nil
     end
 
     it 'should reject a short code with wrong parts.' do
-      CouponCode.validate('CTFM-1K7Q', 2).must_be_nil
+      CouponCode.validate('CTFM-1K7Q', parts: 2).must_be_nil
     end
 
     it 'should fix and validate a lowercase code.' do
@@ -76,14 +76,24 @@ describe CouponCode do
     end
 
     it 'should valid code-pretest.' do
-      CouponCode.validate('1K7Q', 1).wont_be_nil
-      CouponCode.validate('1K7C', 1).must_be_nil
+      CouponCode.validate('1K7Q', parts: 1).wont_be_nil
+      CouponCode.validate('1K7C', parts: 1).must_be_nil
 
-      CouponCode.validate('1K7Q-CTFM', 2).wont_be_nil
-      CouponCode.validate('1K7Q-CTFW', 2).must_be_nil
+      CouponCode.validate('1K7Q-CTFM', parts: 2).wont_be_nil
+      CouponCode.validate('1K7Q-CTFW', parts: 2).must_be_nil
 
-      CouponCode.validate('1K7Q-CTFM-LMTC', 3).wont_be_nil
-      CouponCode.validate('1K7Q-CTFM-LMT1', 3).must_be_nil
+      CouponCode.validate('1K7Q-CTFM-LMTC', parts: 3).wont_be_nil
+      CouponCode.validate('1K7Q-CTFM-LMT1', parts: 3).must_be_nil
+
+      CouponCode.validate('7YQH-1FU7-E1HX-0BG9', parts: 4).wont_be_nil
+      CouponCode.validate('7YQH-1FU7-E1HX-0BGP', parts: 4).must_be_nil
+
+      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYME', parts: 5).wont_be_nil
+      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYMT', parts: 5).must_be_nil
+
+      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYME-RBK1', parts: 6).wont_be_nil
+      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYME-RBK2', parts: 6).must_be_nil
+    end
 
       CouponCode.validate('7YQH-1FU7-E1HX-0BG9', 4).wont_be_nil
       CouponCode.validate('7YQH-1FU7-E1HX-0BGP', 4).must_be_nil

--- a/test/coupon_code_test.rb
+++ b/test/coupon_code_test.rb
@@ -95,14 +95,14 @@ describe CouponCode do
       CouponCode.validate('YENH-UPJK-PTE0-20U6-QYME-RBK2', parts: 6).must_be_nil
     end
 
-      CouponCode.validate('7YQH-1FU7-E1HX-0BG9', 4).wont_be_nil
-      CouponCode.validate('7YQH-1FU7-E1HX-0BGP', 4).must_be_nil
+    it "should allow a default part length to be set" do
+      CouponCode.default_parts(5)
 
-      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYME', 5).wont_be_nil
-      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYMT', 5).must_be_nil
+      code = CouponCode.generate
+      code.split("-").length.must_equal 5
+      CouponCode.validate(code).must_equal code
 
-      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYME-RBK1', 6).wont_be_nil
-      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYME-RBK2', 6).must_be_nil
+      CouponCode.default_parts(3) # Set it back for the rest of the tests
     end
   end
 end

--- a/test/coupon_code_test.rb
+++ b/test/coupon_code_test.rb
@@ -40,23 +40,23 @@ describe CouponCode do
     end
 
     it 'should fail to validate invalid code.' do
-      CouponCode.validate('').must_equal(nil)
+      CouponCode.validate("").must_equal(nil)
     end
 
     it 'should accept a valid code.' do
-      CouponCode.validate('1K7Q-CTFM-LMTC').wont_be_nil
+      CouponCode.validate("1K7Q-CTFM-LMTC").wont_be_nil
     end
 
     it 'should reject a short code.' do
-      CouponCode.validate('1K7Q-CTFM').must_be_nil
+      CouponCode.validate("1K7Q-CTFM").must_be_nil
     end
 
     it 'should accept a short code with correct parts.' do
-      CouponCode.validate('1K7Q-CTFM', parts: 2).wont_be_nil
+      CouponCode.validate("1K7Q-CTFM", parts: 2).wont_be_nil
     end
 
     it 'should reject a short code with wrong parts.' do
-      CouponCode.validate('CTFM-1K7Q', parts: 2).must_be_nil
+      CouponCode.validate("CTFM-1K7Q", parts: 2).must_be_nil
     end
 
     it 'should fix and validate a lowercase code.' do

--- a/test/coupon_code_test.rb
+++ b/test/coupon_code_test.rb
@@ -76,23 +76,23 @@ describe CouponCode do
     end
 
     it 'should valid code-pretest.' do
-      CouponCode.validate('1K7Q', parts: 1).wont_be_nil
-      CouponCode.validate('1K7C', parts: 1).must_be_nil
+      CouponCode.validate("1K7Q", parts: 1).wont_be_nil
+      CouponCode.validate("1K7C", parts: 1).must_be_nil
 
-      CouponCode.validate('1K7Q-CTFM', parts: 2).wont_be_nil
+      CouponCode.validate("1K7Q-CTFM", parts: 2).wont_be_nil
       CouponCode.validate('1K7Q-CTFW', parts: 2).must_be_nil
 
-      CouponCode.validate('1K7Q-CTFM-LMTC', parts: 3).wont_be_nil
-      CouponCode.validate('1K7Q-CTFM-LMT1', parts: 3).must_be_nil
+      CouponCode.validate("1K7Q-CTFM-LMTC", parts: 3).wont_be_nil
+      CouponCode.validate("1K7Q-CTFM-LMT1", parts: 3).must_be_nil
 
-      CouponCode.validate('7YQH-1FU7-E1HX-0BG9', parts: 4).wont_be_nil
-      CouponCode.validate('7YQH-1FU7-E1HX-0BGP', parts: 4).must_be_nil
+      CouponCode.validate("7YQH-1FU7-E1HX-0BG9", parts: 4).wont_be_nil
+      CouponCode.validate("7YQH-1FU7-E1HX-0BGP", parts: 4).must_be_nil
 
-      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYME', parts: 5).wont_be_nil
-      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYMT', parts: 5).must_be_nil
+      CouponCode.validate("YENH-UPJK-PTE0-20U6-QYME", parts: 5).wont_be_nil
+      CouponCode.validate("YENH-UPJK-PTE0-20U6-QYMT", parts: 5).must_be_nil
 
-      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYME-RBK1', parts: 6).wont_be_nil
-      CouponCode.validate('YENH-UPJK-PTE0-20U6-QYME-RBK2', parts: 6).must_be_nil
+      CouponCode.validate("YENH-UPJK-PTE0-20U6-QYME-RBK1", parts: 6).wont_be_nil
+      CouponCode.validate("YENH-UPJK-PTE0-20U6-QYME-RBK2", parts: 6).must_be_nil
     end
 
     it "should allow a default part length to be set" do


### PR DESCRIPTION
Hi there,

I came across an issue where I couldn't validate codes longer than 3 parts. Turns out, it wasnt documented, and I just needed to add the parts as a second positional argument.

This however is inconsistent with the interface for the generate method.

I've updated the validate method's arguments to match those of generates, and have also added a feature to set a default parts length.

I've also updated the readme (but only in english, I don't speak Korean unfortunately), and bumped the version.

I hope you find the changes to your liking :) Thanks again.
